### PR TITLE
fix phplint warnings

### DIFF
--- a/lib/Horde/Service/Weather.php
+++ b/lib/Horde/Service/Weather.php
@@ -351,8 +351,8 @@ class Horde_Service_Weather
             return $temperature;
         }
 
-        $from = strtolower($from{0});
-        $to   = strtolower($to{0});
+        $from = strtolower($from[0]);
+        $to   = strtolower($to[0]);
 
         $result = array(
             'f' => array(

--- a/lib/Horde/Service/Weather/Parser/Metar.php
+++ b/lib/Horde/Service/Weather/Parser/Metar.php
@@ -545,10 +545,10 @@ class Horde_Service_Weather_Parser_Metar extends Horde_Service_Weather_Parser_Ba
                             'presschng' => Horde_Service_Weather::convertPressure($result[2] / 10, 'hpa', $this->_unitMap[self::UNIT_KEY_PRESSURE]),
                             'description' => ($result[1] >= 0 && $result[1] <=3)
                                 ? Horde_Service_Weather_Translation::t('Rising')
-                                : ($result[1] == 4)
+                                : (($result[1] == 4)
                                     ? Horde_Service_Weather_Translation::t('Steady')
-                                    : ($result[1] > 4)
-                                        ? Horde_Service_Weather_Translation::t('Falling') : ''
+                                    : (($result[1] > 4)
+                                        ? Horde_Service_Weather_Translation::t('Falling') : ''))
                         );
                         unset($metarCode['3hpresstend']);
                         break;


### PR DESCRIPTION
```
$ find lib -name \*.php -exec php74 -l {} \;
PHP Deprecated:  Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in lib/Horde/Service/Weather/Parser/Metar.php on line 546
PHP Deprecated:  Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` in lib/Horde/Service/Weather/Parser/Metar.php on line 546
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in lib/Horde/Service/Weather.php on line 354
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in lib/Horde/Service/Weather.php on line 355

```